### PR TITLE
Adds binary operations `either` and `both` in Core, and updates DelayedList implementation.

### DIFF
--- a/lib/logos/core.ex
+++ b/lib/logos/core.ex
@@ -14,12 +14,24 @@ defmodule Logos.Core do
   def success(), do: fn state -> D.single(state) end
 
   @doc """
-  Return a goal that yields an empty stream.
+  Return a goal that yields an empty delayed list.
   """
   def failure(), do: fn _state -> D.empty() end
 
   @doc """
   Return a goal that attempts to unify a pair of terms.
+
+  ## Examples
+
+    iex> import Logos.Core
+    iex> alias Logos.Variable, as: V
+    iex> equal(1, 1) |> call_on_empty() |> Enum.to_list()
+    [%Logos.State{count: 0, sub: %{}}]
+    iex> equal(1, 2) |> call_on_empty() |> Enum.to_list()
+    []
+    iex> x = V.new(:x)
+    iex> equal(x, 1) |> call_on_empty() |> Enum.to_list()
+    [%Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 1}}]
   """
   def equal(term1, term2) do
     fn %S{} = state ->
@@ -27,6 +39,50 @@ defmodule Logos.Core do
         {:ok, s} -> D.single(s)
         :error -> D.empty()
       end
+    end
+  end
+
+  @doc """
+  Return a goal that represents the disjunction of a pair of goals. If the goal is
+  successful then _either_ input goal, but at least one, is successful.
+
+  ## Examples
+
+    iex> import Logos.Core
+    iex> alias Logos.Variable, as: V
+    iex> x = V.new(:x)
+    iex> either(equal(x, 1), equal(x, 2)) |> call_on_empty() |> Enum.to_list()
+    [
+      %Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 1}},
+      %Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 2}}
+    ]
+  """
+  def either(goal1, goal2) do
+    fn %S{} = state ->
+      D.mplus(
+        delay(state, goal1),
+        delay(state, goal2)
+      )
+    end
+  end
+
+  @doc """
+  Return a goal that represents the conjunction of a pair of goals. If the goal is
+  successful then _both_ input goals must be successful.
+
+  ## Examples
+
+    iex> import Logos.Core
+    iex> alias Logos.Variable, as: V
+    iex> x = V.new(:x)
+    iex> both(equal(x, 1), equal(2, 2)) |> call_on_empty() |> Enum.to_list()
+    [%Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 1}}]
+    iex> both(equal(x, 1), equal(x, 2)) |> call_on_empty() |> Enum.to_list()
+    []
+  """
+  def both(goal1, goal2) do
+    fn %S{} = state ->
+      D.bind(delay(state, goal1), goal2)
     end
   end
 
@@ -62,6 +118,15 @@ defmodule Logos.Core do
   def with_var(var_to_goal) when is_function(var_to_goal, 1) do
     fn %S{count: c} = state ->
       state |> S.inc_count() |> var_to_goal.(V.new(c)).()
+    end
+  end
+
+  @doc """
+  Return a thunk that, when forced, evaluates the goal on the state.
+  """
+  def delay(state, goal) do
+    fn ->
+      goal.(state)
     end
   end
 

--- a/lib/logos/delayed_list.ex
+++ b/lib/logos/delayed_list.ex
@@ -15,6 +15,22 @@ defmodule Logos.DelayedList do
   def single(x), do: [x]
 
   @doc """
+  Binary version of interleave. Using the miniK name for now.
+  """
+  def mplus([], dl2), do: dl2
+  def mplus([h1 | t1], dl2), do: [h1 | fn -> mplus(dl2, t1) end]
+  def mplus(dl1, dl2) when is_function(dl1, 0), do: fn -> mplus(dl2, dl1.()) end
+
+  @doc """
+  Binary versio of flat_map. Using the miniK name for now.
+  """
+  def bind([], _mapper), do: []
+
+  # pause/delay should go here
+  def bind([h | t], mapper), do: mplus(fn -> mapper.(h) end, fn -> bind(t, mapper) end)
+  def bind(dl, mapper) when is_function(dl, 0), do: fn -> bind(dl.(), mapper) end
+
+  @doc """
   Interleave a pair of delayed lists.
 
   This is similar to `mplus` in µKanren.

--- a/test/core_test.exs
+++ b/test/core_test.exs
@@ -1,0 +1,4 @@
+defmodule CoreTest do
+  use ExUnit.Case, async: true
+  doctest Logos.Core
+end


### PR DESCRIPTION
Inclusion of `both` (binary conjunction) and `either` (binary disjunction) is purely additive at this point. The original implementation of `any` and `all` are unmodified, but they will eventually be updated to use `both` and `either` as common roots.

In DelayedList, `bind` and `mplus` have been added to be consistent with the original microKanren implementation and naming. These will likely be eventually be updated with more descriptive names and perhaps tweaks to the default search strategy.