### PR TITLE
Introduce non-relational inequalities.

### DIFF
--- a/lib/logos.ex
+++ b/lib/logos.ex
@@ -5,7 +5,8 @@ defmodule Logos do
 
   defmacro __using__(_opts \\ []) do
     quote do
-      import Logos.Core, only: [all: 1, any: 1, equal: 2, failure: 0, negate: 1, success: 0]
+      import Logos.Core, only: [all: 1, any: 1, equal: 2, failure: 0, success: 0]
+      import Logos.CoreNonRel, only: [gt: 2, gte: 2, lt: 2, lte: 2, negate: 1]
       import Logos.Interface, only: [ask: 2, choice: 1, defrule: 2, fork: 1, neg: 1, with_vars: 2]
       import Logos.Rule
     end

--- a/lib/logos/core.ex
+++ b/lib/logos/core.ex
@@ -9,7 +9,7 @@ defmodule Logos.Core do
   alias Logos.DelayedList, as: D
 
   @doc """
-  Return a goal that leaves the state unaltered and lifts it into a delayed list.
+  Return a goal that leaves the state unaltersed and lifts it into a delayed list.
   """
   def success(), do: fn state -> D.single(state) end
 
@@ -143,50 +143,4 @@ defmodule Logos.Core do
   Call a goal on an empty state and return the result as an Elixir Stream.
   """
   def call_on_empty(goal), do: goal.(S.empty()) |> D.to_stream()
-
-  @doc """
-  Non-relational if-then-else rule. If the _condition_ goal succeeds, the _conclusion_ goal is
-  pursued; otherwise, the _alternative_ goal is pursued.
-  """
-  def switch(goal_cond, goal_conc, goal_alt) do
-    fn %S{} = state ->
-      do_switch(state, goal_cond.(state), goal_conc, goal_alt)
-    end
-  end
-
-  defp do_switch(_state, [_h | _t] = stream, g_conc, _g_else), do: D.flat_map(stream, g_conc)
-  defp do_switch(state, [], _g_conc, g_alt), do: g_alt.(state)
-
-  defp do_switch(state, stream, g_conc, g_alt) when is_function(stream) do
-    fn -> do_switch(state, stream.(), g_conc, g_alt) end
-  end
-
-  @doc """
-  Non-relational _negation as failure_ that effectively negates a single goal.
-
-  WARNING: Experimental.
-  """
-  def negate(goal) do
-    fn %S{} = state ->
-      switch(goal, failure(), success()).(state)
-    end
-  end
-
-  def gt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>/2)
-  def lt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.</2)
-  def gte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>=/2)
-  def lte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.<=/2)
-
-  defp nonrel_inequality(term1, term2, op) when is_function(op) do
-    fn %S{} = state ->
-      term1_walked = S.walk(state, term1)
-      term2_walked = S.walk(state, term2)
-
-      if op.(term1_walked, term2_walked) do
-        D.single(state)
-      else
-        D.empty()
-      end
-    end
-  end
 end

--- a/lib/logos/core.ex
+++ b/lib/logos/core.ex
@@ -171,4 +171,22 @@ defmodule Logos.Core do
       switch(goal, failure(), success()).(state)
     end
   end
+
+  def gt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>/2)
+  def lt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.</2)
+  def gte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>=/2)
+  def lte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.<=/2)
+
+  defp nonrel_inequality(term1, term2, op) when is_function(op) do
+    fn %S{} = state ->
+      term1_walked = S.walk(state, term1)
+      term2_walked = S.walk(state, term2)
+
+      if op.(term1_walked, term2_walked) do
+        D.single(state)
+      else
+        D.empty()
+      end
+    end
+  end
 end

--- a/lib/logos/core_non_rel.ex
+++ b/lib/logos/core_non_rel.ex
@@ -1,0 +1,95 @@
+defmodule Logos.CoreNonRel do
+  @moduledoc """
+  Primitive non-relational rules.
+  """
+
+  alias Logos.Core, as: C
+  alias Logos.State, as: S
+  alias Logos.DelayedList, as: D
+
+  @doc """
+  Non-relational if-then-else rule. If the _condition_ goal succeeds, the _conclusion_ goal is
+  pursued; otherwise, the _alternative_ goal is pursued.
+  """
+  def switch(goal_cond, goal_conc, goal_alt) do
+    fn %S{} = state ->
+      do_switch(state, goal_cond.(state), goal_conc, goal_alt)
+    end
+  end
+
+  defp do_switch(_state, [_h | _t] = stream, g_conc, _g_else), do: D.flat_map(stream, g_conc)
+  defp do_switch(state, [], _g_conc, g_alt), do: g_alt.(state)
+
+  defp do_switch(state, stream, g_conc, g_alt) when is_function(stream) do
+    fn -> do_switch(state, stream.(), g_conc, g_alt) end
+  end
+
+  @doc """
+  Non-relational _negation as failure_ that effectively negates a single goal.
+
+  WARNING: Experimental.
+
+  ## Examples
+
+    iex> import Logos.Core
+    iex> import Logos.CoreNonRel
+    iex> alias Logos.Variable, as: V
+    iex> x = V.new(:x)
+    iex> both(equal(x, 1), negate(equal(x, 2))) |> call_on_empty() |> Enum.to_list()
+    [
+      %Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 1}}
+    ]
+  """
+  def negate(goal) do
+    fn %S{} = state ->
+      switch(goal, C.failure(), C.success()).(state)
+    end
+  end
+
+  @doc """
+  Non-relational _greater than_ (>) for grounded terms.
+
+  ## Examples
+
+    iex> import Logos.Core
+    iex> import Logos.CoreNonRel
+    iex> alias Logos.Variable, as: V
+    iex> x = V.new(:x)
+    iex> both(equal(x, 1), gt(x, 0)) |> call_on_empty() |> Enum.to_list()
+    [
+      %Logos.State{count: 0, sub: %{%Logos.Variable{id: :x} => 1}}
+    ]
+    iex> both(equal(x, 1), gt(x, 10)) |> call_on_empty() |> Enum.to_list()
+    []
+  """
+  def gt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>/2)
+
+  @doc """
+  Non-relational less than_ (<) for grounded terms.
+  """
+  def lt(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.</2)
+
+  @doc """
+  Non-relational _greater than or equal_ (>=) for grounded terms.
+  """
+  def gte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.>=/2)
+
+  @doc """
+  Non-relational _less than or equal_ (<=) for grounded terms.
+  """
+  def lte(term1, term2), do: nonrel_inequality(term1, term2, &Kernel.<=/2)
+
+  # Abstracted implementation of non-relational inequalities.
+  defp nonrel_inequality(term1, term2, op) when is_function(op) do
+    fn %S{} = state ->
+      term1_walked = S.walk(state, term1)
+      term2_walked = S.walk(state, term2)
+
+      if op.(term1_walked, term2_walked) do
+        D.single(state)
+      else
+        D.empty()
+      end
+    end
+  end
+end

--- a/lib/logos/interface.ex
+++ b/lib/logos/interface.ex
@@ -4,6 +4,7 @@ defmodule Logos.Interface do
   """
 
   alias Logos.Core, as: C
+  alias Logos.CoreNonRel, as: CNR
   alias Logos.Variable, as: V
   alias Logos.Presentation, as: P
   alias Logos.Interface, as: I
@@ -90,7 +91,7 @@ defmodule Logos.Interface do
   end
 
   @doc """
-  "Impure" relation that evaluates the first consequence whose corresponding condition goal is
+  Non-relational rule that evaluates the first consequence whose corresponding condition goal is
   successful. Implicit conjunction is allowed for both the condition and consequence clauses.
   This is essentially eqivalent to `conda` in miniKanren.
   """
@@ -110,7 +111,7 @@ defmodule Logos.Interface do
 
   defp do_choice(g_cond, g_cnsq, [_h | _t] = clauses) do
     quote do
-      C.switch(
+      CNR.switch(
         I.implicit_all(unquote(g_cond)),
         I.implicit_all(unquote(g_cnsq)),
         I.choice(do: unquote(clauses))

--- a/test/core_non_rel_test.exs
+++ b/test/core_non_rel_test.exs
@@ -1,0 +1,4 @@
+defmodule CoreNonRelTest do
+  use ExUnit.Case, async: true
+  doctest Logos.CoreNonRel
+end


### PR DESCRIPTION
This PR introduces non-relational inequalities as Logos rules:

`gt` (greater than)
`lt` (less than)
`gte` (greater than or equal)
`lte` (less than or equal)

These functions are located in `Logos.CoreNonRel`. The `negate` rule was moved from `Logos.Core` to `Logos.CoreNonRel`, and any dependencies were updated.